### PR TITLE
Review of FAST.Farm Changes Regarding Polar to Rectangular Grid

### DIFF
--- a/modules/awae/src/AWAE.f90
+++ b/modules/awae/src/AWAE.f90
@@ -210,8 +210,6 @@ subroutine LowResGridCalcOutput(n, u, p, y, m, errStat, errMsg)
    real(ReKi)          :: xplane_sq, yplane_sq, xysq_Z(3), xzplane_X(3)
    real(ReKi), ALLOCATABLE :: tmp_xhat_plane(:,:), tmp_yhat_plane(:,:), tmp_zhat_plane(:,:)
    real(ReKi), ALLOCATABLE :: tmp_Vx_wake(:), tmp_Vz_wake(:), tmp_Vy_wake(:)
-   real(ReKi)          :: Vx_debug
-   integer(IntKi)      :: ILo
    integer(IntKi)      :: maxPln, tmpPln, maxN_wake
    integer(IntKi)      :: i,np1,errStat2
    character(*), parameter   :: RoutineName = 'LowResGridCalcOutput'
@@ -242,7 +240,7 @@ subroutine LowResGridCalcOutput(n, u, p, y, m, errStat, errMsg)
 
       ! Loop over the entire grid of low resolution ambient wind data to compute:
       !    1) the disturbed flow at each point and 2) the averaged disturbed velocity of each wake plane
-   !$OMP PARALLEL DO PRIVATE(nx_low,ny_low,nz_low, nXYZ_low, n_wake, xhatBar_plane, x_end_plane,nt,np,ILo,x_start_plane,delta,deltad,Vx_debug,&
+   !$OMP PARALLEL DO PRIVATE(nx_low,ny_low,nz_low, nXYZ_low, n_wake, xhatBar_plane, x_end_plane,nt,np,x_start_plane,delta,deltad,&
    !$OMP&                    p_tmp_plane,tmp_vec,r_vec_plane,y_tmp_plane,z_tmp_plane,xhatBar_plane_norm, Vx_wake_tmp, Vr_wake_tmp,&
    !$OMP&                    nw,Vr_term,Vx_term,tmp_x,tmp_y,tmp_z,&
    !$OMP&                    xHat_plane, yHat_plane, zHat_plane,&
@@ -277,8 +275,6 @@ subroutine LowResGridCalcOutput(n, u, p, y, m, errStat, errMsg)
                x_end_plane = tmp_x + tmp_y + tmp_z
 
                do np = 0, maxPln
-                  ! Reset interpolation counter
-                  ILo = 0 ! TODO, curently not used
                   np1 = np + 1
                   ! Construct the endcaps of the current wake plane volume
                   x_start_plane = x_end_plane
@@ -333,7 +329,7 @@ subroutine LowResGridCalcOutput(n, u, p, y, m, errStat, errMsg)
                         ! Increment number of wakes contributing to current grid point
                         n_wake = n_wake + 1
 
-                        ! Store unit vectors for projection, TODO Compute Vr_term directly
+                        ! Store unit vectors for projection
                         tmp_xhat_plane(:,n_wake) = xHat_plane
                         tmp_yhat_plane(:,n_wake) = yHat_plane
                         tmp_zhat_plane(:,n_wake) = zHat_plane
@@ -427,7 +423,7 @@ subroutine LowResGridCalcOutput(n, u, p, y, m, errStat, errMsg)
 
                 Vsum_low  = 0.0_ReKi
                 iwsum = 0
-                n_r_polar = FLOOR((p%C_Meander*u%D_wake(np,nt))/(2.0_ReKi*p%dpol)) ! TODO change me Dwake*sqrt(2)?
+                n_r_polar = FLOOR((p%C_Meander*u%D_wake(np,nt))/(2.0_ReKi*p%dpol))
 
                 do nr = 0,n_r_polar
 
@@ -567,7 +563,7 @@ subroutine HighResGridCalcOutput(n, u, p, y, m, errStat, errMsg)
    real(ReKi)          :: p_tmp_plane(3)
    real(ReKi)          :: tmp_vec(3)
    real(ReKi)          :: delta, deltad
-   integer(IntKi)      :: np1, ILo
+   integer(IntKi)      :: np1
    integer(IntKi)      :: maxPln
    integer(IntKi)      :: n_high_low
    character(*), parameter   :: RoutineName = 'HighResGridCalcOutput'
@@ -612,8 +608,6 @@ subroutine HighResGridCalcOutput(n, u, p, y, m, errStat, errMsg)
                      x_end_plane = dot_product(u%xhat_plane(:,0,nt2), (p%Grid_high(:,nXYZ_high,nt) - u%p_plane(:,0,nt2)) )
 
                      do np = 0, maxPln !p%NumPlanes-2
-                        ! Reset interpolation counter
-                        ILo = 0 ! TODO, curently not used
                         np1 = np + 1
                         ! Construct the endcaps of the current wake plane volume
                         x_start_plane = x_end_plane
@@ -663,7 +657,7 @@ subroutine HighResGridCalcOutput(n, u, p, y, m, errStat, errMsg)
                               ! Increment number of wakes contributing to current grid point
                               n_wake = n_wake + 1
 
-                              ! Store unit vectors for projection, TODO Compute Vr_term directly
+                              ! Store unit vectors for projection
                               m%xhat_plane(:,n_wake) = xHat_plane
                               m%yhat_plane(:,n_wake) = yHat_plane
                               m%zhat_plane(:,n_wake) = zHat_plane

--- a/modules/awae/src/AWAE_Registry.txt
+++ b/modules/awae/src/AWAE_Registry.txt
@@ -212,8 +212,8 @@ typedef   ^ OutputType     ReKi       Vx_wind_disk {:}                    -     
 # Define inputs that are contained on the mesh here:
 typedef   ^ InputType      ReKi       xhat_plane   {:}{:}{:}              -      -      "Orientations of wake planes, normal to wake planes, for each turbine"      -
 typedef   ^ InputType      ReKi       p_plane      {:}{:}{:}              -      -      "Center positions of wake planes for each turbine"      m
-typedef   ^ InputType      ReKi       Vx_wake      {:}{:}{:}{:}           -      -      "Axial wake velocity deficit at wake planes, distributed acrros the plane, for each turbine (ny,nz,np,nWT)"      m/s
-typedef   ^ InputType      ReKi       Vy_wake      {:}{:}{:}{:}           -      -      "Transverse horizonal wake velocity deficit at wake planes, distributed acrros the plane, for each turbine (ny,nz,np,nWT)"      m/s
-typedef   ^ InputType      ReKi       Vz_wake      {:}{:}{:}{:}           -      -      "Transverse nominally vertical wake velocity deficit at wake planes, distributed acrros the plane, for each turbine (ny,nz,np,nWT)"      m/s
+typedef   ^ InputType      ReKi       Vx_wake      {:}{:}{:}{:}           -      -      "Axial wake velocity deficit at wake planes, distributed across the plane, for each turbine (ny,nz,np,nWT)"      m/s
+typedef   ^ InputType      ReKi       Vy_wake      {:}{:}{:}{:}           -      -      "Transverse horizonal wake velocity deficit at wake planes, distributed across the plane, for each turbine (ny,nz,np,nWT)"      m/s
+typedef   ^ InputType      ReKi       Vz_wake      {:}{:}{:}{:}           -      -      "Transverse nominally vertical wake velocity deficit at wake planes, distributed across the plane, for each turbine (ny,nz,np,nWT)"      m/s
 typedef   ^ InputType      ReKi       D_wake       {:}{:}                 -      -      "Wake diameters at wake planes for each turbine"     m
 

--- a/modules/wakedynamics/src/WakeDynamics.f90
+++ b/modules/wakedynamics/src/WakeDynamics.f90
@@ -1103,25 +1103,6 @@ subroutine WD_CalcOutput( t, u, p, x, xd, z, OtherState, y, m, errStat, errMsg )
       call Axisymmetric2Cartesian(y%Vx_wake(:,i), y%Vr_wake(:,i), p%r, p%y, p%z, y%Vx_wake2(:,:,i), y%Vy_wake2(:,:,i), y%Vz_wake2(:,:,i))
    enddo
 
-   ! DEBUG check
-   do i = 0, min(n+1,p%NumPlanes-1)
-      if( any(abs(y%Vx_wake2(0:,0,i)-y%Vx_wake(:,i))>1e-20)) then
-         print*,'Problem Vx',i
-         print*,'y%Vx_wake2(0:,0,i)',y%Vx_wake2(0:,0,i)
-         print*,'y%Vx_wake(:,i)',y%Vx_wake(:,i)
-         STOP
-      endif
-      !y%Vy_wake2(0:,0,:)
-      if (any(abs(y%Vy_wake2(0:,0,i)-y%Vr_wake(:,i))>1e-9)) then
-         print*,'Problem Vr',i
-         print*,'y%Vx_wake2(0:,0,i)',y%Vy_wake2(0:,0,i)
-         print*,'y%Vx_wake(:,i)',y%Vr_wake(:,i)
-         STOP
-      endif
-   enddo
-
-
-
    
 end subroutine WD_CalcOutput
 
@@ -1211,8 +1192,9 @@ subroutine InitStatesWithInputs(numPlanes, numRadii, u, p, xd, m, errStat, errMs
    
    xd%Vx_rel_disk_filt     = u%Vx_rel_disk    
    
-      ! Initialze Ct_azavg_filt and Vx_wake; Vr_wake is already initialized to zero, so, we don't need to do that here.
-   xd%Ct_azavg_filt (:) = u%Ct_azavg(:) 
+      ! Initialze Ct_azavg_filt, Cq_azavg_filt, and Vx_wake; Vr_wake is already initialized to zero, so, we don't need to do that here.
+   xd%Ct_azavg_filt (:) = u%Ct_azavg(:)
+   xd%Cq_azavg_filt (:) = u%Cq_azavg(:)
    
    call NearWakeCorrection( xd%Ct_azavg_filt, xd%Cq_azavg_filt, xd%Vx_rel_disk_filt, p, m, xd%Vx_wake(:,0), xd%D_rotor_filt(0), errStat, errMsg )
    xd%Vx_wake(:,1) = xd%Vx_wake(:,0)


### PR DESCRIPTION
Thanks, @ebranlard, I've reviewed your changes.  Please find a few small edits in this pull request: 
*Fixed a couple bugs in recent FAST.Farm changes.
*Eliminated debug states and unneeded variables.
*Fixed a few typos.

Please note that I did not fully review the updates to SUBROUTINE WD_UpdateStates because the reordering of the loops caused many changes that were difficult to track.  I assume that the testing would have uncovered any bugs.

I only gave a cursory look at new interp2D() FUNCTION in _AWEA.f90_.  I asked Bonnie and she said that there are others implemented in the code, but they are not in the NWTC library, and so, are difficult to call and what you did here is OK.

I also think the new filter_angles() FUNCTION in _WakeDynamics.f90_ looks fine.  I asked Bonnie and she said the AddOrSub2Pi() SUBROUTINE could be used together with the linear interpolation, but what you've implemented looks like a fine substitute.

Once curled wake is fully implemented, we should change SUBROUTINE WD_CalcOutput() so that both Vx_wake and Vx_wake2, etc. are not both output.